### PR TITLE
chore: not specify clang version explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,8 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh 18
         rm llvm.sh
+    - name: Fix llvm-ar path
+      run: |
+        sudo ln -s $(which llvm-ar-18) /usr/bin/llvm-ar || true
     - name: Build
       run: make

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 CC := clang
-LD := ld.lld
-OBJCOPY := llvm-objcopy
 AR := llvm-ar
-RANLIB := llvm-ranlib
 
 CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
 CFLAGS += -Os

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,8 @@
-CC := clang-18
-LD := ld.lld-18
-OBJCOPY := llvm-objcopy-18
-AR := llvm-ar-18
-RANLIB := llvm-ranlib-18
-
-UNAME := $(shell uname)
-ifeq ($(UNAME), Darwin)
-	LD := ld.lld
-	OBJCOPY := llvm-objcopy
-	RANLIB := llvm-ranlib
-	AR := llvm-ar
-endif
+CC := clang
+LD := ld.lld
+OBJCOPY := llvm-objcopy
+AR := llvm-ar
+RANLIB := llvm-ranlib
 
 CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
 CFLAGS += -Os


### PR DESCRIPTION
Due to system compatibility and maintenance considerations:
1. Version suffix specification is not supported on certain systems (e.g., macOS, Nix)
2. Makefile requires manual updates when upgrading Clang versions
