### PR TITLE
Add CFI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,17 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Install llvm 18
+    - name: Install llvm 21
       run: |
-        sudo apt-get purge --auto-remove llvm python3-lldb-14 llvm-14
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 18
+        sudo ./llvm.sh 21
         rm llvm.sh
-    - name: Fix llvm-ar path
+    - name: Fix llvm path
       run: |
-        sudo ln -s $(which llvm-ar-18) /usr/bin/llvm-ar || true
+        sudo ln -sf $(which llvm-ar-21) /usr/bin/llvm-ar
+        sudo ln -sf $(which clang-21) /usr/bin/clang
     - name: Build
       run: make
+    - name: Build with CFI enabled
+      run: make clean && make CFI=unlabeled

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,25 @@
 CC := clang
 AR := llvm-ar
 
+ifdef CFI
+$(info Info: build with CFI enabled)
+CLANG_VERSION := $(shell $(CC) --version | head -n1 | sed -n 's/.*version \([0-9]*\)\..*/\1/p')
+ifeq ($(shell test $(CLANG_VERSION) -ge 21; echo $$?),0)
+CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs_zicfiss1p0_zicfilp1p0 -mabi=lp64
+CFLAGS += -menable-experimental-extensions -fcf-protection=full
+ifeq ($(CFI),unlabeled)
+CFLAGS += -mcf-branch-label-scheme=unlabeled
+else ifeq ($(CFI),func-sig)
+CFLAGS += -mcf-branch-label-scheme=func-sig
+else
+$(error Error: CFI is set to '$(CFI)' but expected 'unlabeled' or 'func-sig')
+endif
+else
+$(error Error: CFI requires clang version 21 or above, but found version $(CLANG_VERSION))
+endif
+else
 CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
+endif
 CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections -fno-builtin -fvisibility=hidden -fomit-frame-pointer
 CFLAGS += -I compiler-rt/lib/builtins

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,25 @@ CC := clang
 AR := llvm-ar
 
 ifdef CFI
-$(info Info: build with CFI enabled)
-CLANG_VERSION := $(shell $(CC) --version | head -n1 | sed -n 's/.*version \([0-9]*\)\..*/\1/p')
-ifeq ($(shell test $(CLANG_VERSION) -ge 21; echo $$?),0)
-CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs_zicfiss1p0_zicfilp1p0 -mabi=lp64
-CFLAGS += -menable-experimental-extensions -fcf-protection=full
-ifeq ($(CFI),unlabeled)
-CFLAGS += -mcf-branch-label-scheme=unlabeled
-else ifeq ($(CFI),func-sig)
-CFLAGS += -mcf-branch-label-scheme=func-sig
+    $(info Info: build with CFI enabled)
+    CLANG_VERSION := $(shell $(CC) --version | head -n1 | sed -n 's/.*version \([0-9]*\)\..*/\1/p')
+    ifeq ($(shell test $(CLANG_VERSION) -ge 21; echo $$?),0)
+        CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs_zicfiss1p0_zicfilp1p0 -mabi=lp64
+        CFLAGS += -menable-experimental-extensions -fcf-protection=full
+        ifeq ($(CFI),unlabeled)
+            CFLAGS += -mcf-branch-label-scheme=unlabeled
+        else ifeq ($(CFI),func-sig)
+            CFLAGS += -mcf-branch-label-scheme=func-sig
+        else
+            $(error Error: CFI is set to '$(CFI)' but expected 'unlabeled' or 'func-sig')
+        endif
+    else
+        $(error Error: CFI requires clang version 21 or above, but found version $(CLANG_VERSION))
+    endif
 else
-$(error Error: CFI is set to '$(CFI)' but expected 'unlabeled' or 'func-sig')
+    CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
 endif
-else
-$(error Error: CFI requires clang version 21 or above, but found version $(CLANG_VERSION))
-endif
-else
-CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
-endif
+
 CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections -fno-builtin -fvisibility=hidden -fomit-frame-pointer
 CFLAGS += -I compiler-rt/lib/builtins

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,23 @@
 CC := clang
 AR := llvm-ar
 
-ifdef CFI
-    $(info Info: build with CFI enabled)
-    CLANG_VERSION := $(shell $(CC) --version | head -n1 | sed -n 's/.*version \([0-9]*\)\..*/\1/p')
-    ifeq ($(shell test $(CLANG_VERSION) -ge 21; echo $$?),0)
-        CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs_zicfiss1p0_zicfilp1p0 -mabi=lp64
-        CFLAGS += -menable-experimental-extensions -fcf-protection=full
-        ifeq ($(CFI),unlabeled)
-            CFLAGS += -mcf-branch-label-scheme=unlabeled
-        else ifeq ($(CFI),func-sig)
-            CFLAGS += -mcf-branch-label-scheme=func-sig
-        else
-            $(error Error: CFI is set to '$(CFI)' but expected 'unlabeled' or 'func-sig')
-        endif
-    else
-        $(error Error: CFI requires clang version 21 or above, but found version $(CLANG_VERSION))
-    endif
-else
-    CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64
-endif
+define get_cfi_cflags
+$(if $(1),\
+    $(info Info: build with CFI enabled)\
+    $(eval _CLANG_VERSION := $(shell $(CC) --version | head -n1 | sed -n 's/.*version \([0-9]*\)\..*/\1/p'))\
+    $(if $(shell test $(_CLANG_VERSION) -ge 21 && echo 1),\
+        --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs_zicfiss1p0_zicfilp1p0 -mabi=lp64 \
+        -menable-experimental-extensions -fcf-protection=full \
+        $(if $(filter unlabeled,$(1)),\
+            -mcf-branch-label-scheme=unlabeled,\
+        $(if $(filter func-sig,$(1)),\
+            -mcf-branch-label-scheme=func-sig,\
+            $(error Error: CFI is set to '$(1)' but expected 'unlabeled' or 'func-sig'))),\
+        $(error Error: CFI requires clang version 21 or above, but found version $(_CLANG_VERSION))),\
+    --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs -mabi=lp64)
+endef
+
+CFLAGS := $(call get_cfi_cflags,$(CFI))
 
 CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections -fno-builtin -fvisibility=hidden -fomit-frame-pointer


### PR DESCRIPTION
Usage:
```
make CFI=unlabeled
```
or

```
make CFI=func-sig
```
Note, llvm 21 doesn't support func-sig yet. We keep it here for further usage.

